### PR TITLE
Fourier Transform based baseline subtraction

### DIFF
--- a/pyquant/__init__.py
+++ b/pyquant/__init__.py
@@ -92,7 +92,7 @@ peak_parameters.add_argument(
     default=PEAK_FIT_MODE_AVERAGE
 )
 peak_parameters.add_argument('--gap-interpolation', help='This interpolates missing data in scans. The parameter should be a number that is the maximal gap size to fill (ie 2 means a gap of 2 scans). Can be useful for low intensity LC-MS data.', type=int, default=0)
-peak_parameters.add_argument('--remove-baseline', help='Fit a separate line for the baseline of each peak.', action='store_true')
+peak_parameters.add_argument('--fit-baseline', help='Fit a separate line for the baseline of each peak.', action='store_true')
 peak_parameters.add_argument('--peak-cutoff', help='The threshold from the initial retention time a peak can fall by before being discarded', type=float, default=0.05)
 peak_parameters.add_argument('--max-peaks', help='The maximal number of peaks to detect per scan. A lower value can help with very noisy data.', type=int, default=-1)
 peak_parameters.add_argument('--peaks-n', help='The number of peaks to report per scan. Useful for ions with multiple elution times.', type=int, default=1)
@@ -107,6 +107,9 @@ peak_parameters.add_argument('--min-peak-separation', help='Peaks separated by l
 peak_parameters.add_argument('--disable-peak-filtering', help='This will disable smoothing of data prior to peak finding. If you have very good LC, this may be used to identify small peaks.', action='store_true')
 peak_parameters.add_argument('--merge-isotopes', help='Merge Isotopologues together prior to fitting.', action='store_true')
 peak_parameters.add_argument('--peak-resolution-mode', help='The method to use to resolve peaks across multiple XICs', choices=(PEAK_RESOLUTION_RT_MODE, PEAK_RESOLUTION_COMMON_MODE), type=str, default='common-peak')
+
+# Deprecated parameters
+peak_parameters.add_argument('--remove-baseline', help=argparse.SUPPRESS, action='store_true', dest='fit_baseline')
 
 
 xic_parameters = pyquant_parser.add_argument_group('XIC Options')

--- a/pyquant/peaks.py
+++ b/pyquant/peaks.py
@@ -22,7 +22,14 @@ from pyquant.cpeaks import bigauss_func, gauss_func, bigauss_ndim, gauss_ndim, b
     gauss_jac, find_nearest, find_nearest_index, get_ppm
 from . import PEAK_FINDING_REL_MAX, PEAK_FIT_MODE_AVERAGE, PEAK_FIT_MODE_FAST, PEAK_FIT_MODE_SLOW
 from .logger import logger
-from .utils import divide_peaks, find_possible_peaks, estimate_peak_parameters, interpolate_data, savgol_smooth
+from .utils import (
+    divide_peaks,
+    find_possible_peaks,
+    estimate_peak_parameters,
+    interpolate_data,
+    savgol_smooth,
+    subtract_baseline,
+)
 
 if six.PY3:
     xrange = range
@@ -257,22 +264,29 @@ def findEnvelope(xdata, ydata, measured_mz=None, theo_mz=None, max_mz=None, prec
 
 def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_size=0, filter=False, peak_boost=False, bigauss_fit=False,
                  rt_peak=None, mrm=False, max_peaks=4, debug=False, peak_width_start=3, snr=0, zscore=0, amplitude_filter=0,
-                 peak_width_end=4, baseline_correction=False, rescale=True, fit_negative=False, percentile_filter=0, micro=False,
+                 peak_width_end=4, fit_baseline=False, rescale=True, fit_negative=False, percentile_filter=0, micro=False,
                  method_opts=None, smooth=False, r2_cutoff=None, peak_find_method=PEAK_FINDING_REL_MAX, min_slope=None,
                  min_peak_side_width=3, gap_interpolation=0, min_peak_width=None, min_peak_increase=None, chunk_factor=0.1,
-                 fit_mode=PEAK_FIT_MODE_AVERAGE):
+                 fit_mode=PEAK_FIT_MODE_AVERAGE, baseline_subtraction=False, **kwargs):
+
+    # Deprecation things
+    if 'baseline_correction' in kwargs:
+        fit_baseline = kwargs['baseline_correction']
 
     if micro:
-        baseline_correction = False
+        fit_baseline = False
 
     if not micro and gap_interpolation:
         ydata_original = interpolate_data(xdata, ydata_original, gap_limit=gap_interpolation)
 
-    rel_peak_constraint = (0.0 if baseline_correction else 0.5)
+    rel_peak_constraint = (0.0 if fit_baseline else 0.5)
     original_max = np.abs(ydata_original).max() if fit_negative else ydata_original.max()
     amplitude_filter /= original_max
     ydata = ydata_original / original_max
     ydata_peaks = np.copy(ydata)
+
+    if baseline_subtraction:
+        ydata_peaks = subtract_baseline(ydata_peaks)
 
     if smooth and len(ydata) > 5:
         ydata_peaks = savgol_smooth(ydata_peaks)
@@ -327,7 +341,7 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
     logger.debug('found: {}\n'.format(final_peaks))
 
     step_size = 4 if bigauss_fit else 3
-    if baseline_correction:
+    if fit_baseline:
         step_size += 2
     min_spacing = min(np.diff(xdata)) / 2
     peak_range = xdata[-1] - xdata[0]
@@ -335,7 +349,7 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
     initial_bounds = [(-1.01, 1.01), (xdata[0], xdata[-1]), (min_spacing, peak_range)]
     if bigauss_fit:
         initial_bounds.extend([(min_spacing, peak_range)])
-    if baseline_correction:
+    if fit_baseline:
         initial_bounds.extend([(None, None), (None, None)])
         # print(final_peaks)
     if debug:
@@ -392,13 +406,13 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
                 rel_peak_constraint=rel_peak_constraint,
                 micro=micro,
                 bigauss_fit=bigauss_fit,
-                baseline_correction=baseline_correction
+                fit_baseline=fit_baseline
             )
 
             if not segment_guess:
                 continue
 
-            args = (segment_x, segment_y, baseline_correction)
+            args = (segment_x, segment_y, fit_baseline)
             opts = method_opts or {'maxiter': 1000}
 
             # Because the amplitude of peaks can vary wildly, we have to make sure our tolerance matters for the
@@ -435,7 +449,7 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
                     if segment_bounds[i][1] > segment_x[-1]:
                         segment_bounds[i] = (segment_bounds[i][0], segment_x[-1])
 
-            if baseline_correction:
+            if fit_baseline:
                 jacobian = None
             else:
                 jacobian = bigauss_jac if bigauss_fit else gauss_jac
@@ -485,7 +499,7 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
                 # Rescale our data back
                 # Amplitude
                 res.x[::step_size] *= segment_max
-                if baseline_correction:
+                if fit_baseline:
                     # Slope
                     res.x[step_size-2::step_size] *= segment_max
                     # Intercept
@@ -585,7 +599,7 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
                 fitted_data -= peak_func(fitted_x, best_fit[other_peak_index:other_peak_index + step_size])
             ss_tot = np.sum((fitted_data - np.mean(fitted_data)) ** 2)
             explained_data = peak_func(fitted_x, peak_info)
-            if baseline_correction:
+            if fit_baseline:
                 explained_data += fitted_x*peak_info[-2]+peak_info[-1]
             ss_res = np.sum((fitted_data - explained_data) ** 2)
             coeff_det = 1 - (ss_res / ss_tot)
@@ -596,9 +610,9 @@ def findAllPeaks(xdata, ydata_original, min_dist=0, method=None, local_filter_si
 
     residual = sum((ydata-peak_func(xdata, best_fit))**2)
 
-    if rescale:  # and not baseline_correction:
+    if rescale:  # and not fit_baseline:
         best_fit[::step_size] *= original_max
-        if baseline_correction:
+        if fit_baseline:
             # Slope
             best_fit[step_size-2::step_size] *= original_max
             # Intercept
@@ -697,7 +711,7 @@ def targeted_search(merged_x, merged_y, x_value, attempts=4, max_peak_distance=1
     stepsize = 3
     if find_peaks_kwargs.get('bigauss_fit'):
         stepsize += 1
-    if find_peaks_kwargs.get('baseline_correction'):
+    if find_peaks_kwargs.get('fit_baseline'):
         stepsize += 2
     while rt_attempts < attempts and not found_rt:
         logger.debug('MERGED PEAK FINDING ATTEMPT %s', rt_attempts)

--- a/pyquant/tests/test_peaks.py
+++ b/pyquant/tests/test_peaks.py
@@ -41,7 +41,7 @@ class PeakFindingTests(FileMixins, unittest.TestCase):
         params, residual = peaks.findAllPeaks(x, y, max_peaks=1, rt_peak=360, fit_mode=PEAK_FIT_MODE_FAST)
         np.testing.assert_allclose(params[1], desired=365.78, atol=0.1)
 
-    def test_baseline_correction_derivative(self):
+    def test_fit_baseline_derivative(self):
         with open(os.path.join(self.data_dir, 'peak_data.pickle'), 'rb') as peak_file:
             data = pickle.load(peak_file, encoding='latin1') if six.PY3 else pickle.load(peak_file)
 
@@ -50,7 +50,7 @@ class PeakFindingTests(FileMixins, unittest.TestCase):
             x,
             y,
             max_peaks=1,
-            baseline_correction=True,
+            fit_baseline=True,
             rt_peak=328,
             peak_find_method='derivative',
             fit_mode=PEAK_FIT_MODE_FAST,

--- a/pyquant/tests/test_utils.py
+++ b/pyquant/tests/test_utils.py
@@ -184,6 +184,21 @@ class UtilsTests(GaussianMixin, unittest.TestCase):
         self.assertAlmostEqual(resolution, 90781.241173982111)
 
 
+    def test_subtract_baseline(self):
+        # This test data is a simple sin function with a parabola function applied to the ends,
+        # giving a smile shape.
+        from scipy import signal
+        x = np.linspace(-50, 50)
+        noise = 0.00125 * x ** 2
+        c1 = np.sin(x)
+        y = noise + c1
+
+        baselined = utils.subtract_baseline(y)
+
+        # Assert we're about zero and the noise (the parabola) has been removed
+        self.assertTrue(sum(baselined-c1) < 1e-10)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyquant/utils.py
+++ b/pyquant/utils.py
@@ -31,6 +31,7 @@ def merge_list(starting_list):
     final_list.append(starting_list[-1])
     return final_list
 
+
 def findValleys(y, srt):
     peak = y.iloc[srt]
     for left in xrange(srt-1, -1, -1):
@@ -44,6 +45,7 @@ def findValleys(y, srt):
             break
     return left, right
 
+
 def fit_theo_dist(params, ny, ty):
     right_limit, scaling = params
     index = xrange(len(ny)) if len(ny) > len(ty) else xrange(len(ty))
@@ -53,6 +55,7 @@ def fit_theo_dist(params, ny, ty):
     exp_dist[int(right_limit):] = 0
     theo_dist += ty
     return ((exp_dist-theo_dist*scaling)**2).sum()
+
 
 def looper(selected=None, df=None, theo=None, index=0, out=None):
     if out is None:
@@ -591,6 +594,7 @@ def get_cross_points(data, pad=True):
 
     return cross_points
 
+
 def find_peaks_derivative(xdata, ydata, ydata_peaks=None, min_slope=None, rel_peak_height=None,
                           min_peak_side_width=2, max_peak_side_width=np.inf,
                           min_peak_width=None, max_peak_width=np.inf, smooth=True):
@@ -723,7 +727,7 @@ def merge_close_peaks(peaks_found, ydata, distance=2):
 
 
 def estimate_peak_parameters(xdata, ydata, row_peaks, minima_array, fit_negative=False, rel_peak_constraint=0, micro=False,
-                             bigauss_fit=False, baseline_correction=False):
+                             bigauss_fit=False, fit_baseline=False):
     guess = []
     bnds = []
     last_peak = -1
@@ -824,7 +828,7 @@ def estimate_peak_parameters(xdata, ydata, row_peaks, minima_array, fit_negative
                 guess.extend([rel_peak, xdata[peak_index], variance, variance])
             else:
                 guess.extend([rel_peak, xdata[peak_index], variance])
-            if baseline_correction:
+            if fit_baseline:
                 slope = (ydata[right] - ydata[left]) / (xdata[right] - xdata[left])
                 intercept = ((ydata[right] - slope * xdata[right]) + (ydata[left] - slope * xdata[left])) / 2
                 guess.extend([slope, intercept])
@@ -839,7 +843,7 @@ def estimate_peak_parameters(xdata, ydata, row_peaks, minima_array, fit_negative
         guess = [max(ydata), average, variance]
         if bigauss_fit:
             guess.extend([variance])
-        if baseline_correction:
+        if fit_baseline:
             slope = (ydata[-1] - ydata[0]) / (xdata[-1] - xdata[0])
             intercept = ((ydata[-1] - slope * xdata[-1]) + (ydata[0] - slope * xdata[0])) / 2
             guess.extend([slope, intercept])
@@ -921,3 +925,17 @@ def get_scan_resolution(scan):
 
     fwhm = peaks[2+largest_peak*3]*2.355
     return peaks[1+largest_peak*3]/fwhm
+
+
+def subtract_baseline(y, components_to_remove=10, dampen_factor=10):
+    from scipy import fftpack, signal
+    f = fftpack.rfft(y)
+    f[:components_to_remove] = 0
+    fs = fftpack.fftshift(f)
+
+    # filter it
+    filtered = (fs * (1 - signal.gaussian(len(y), dampen_factor))) if dampen_factor else fs
+    # invert it
+    final = fftpack.irfft(fftpack.ifftshift(filtered))
+
+    return final

--- a/pyquant/worker.py
+++ b/pyquant/worker.py
@@ -89,7 +89,7 @@ class Worker(Process):
         self.rt_guide = not self.parser_args.no_rt_guide
         self.filter_peaks = not self.parser_args.disable_peak_filtering
         self.report_ratios = not self.parser_args.no_ratios
-        self.bigauss_stepsize = 6 if self.parser_args.remove_baseline else 4
+        self.bigauss_stepsize = 6 if self.parser_args.fit_baseline else 4
         self.xic_missing_ion_count = self.parser_args.xic_missing_ion_count
 
         self.scans_to_skip = scans_to_skip or {}
@@ -102,7 +102,7 @@ class Worker(Process):
             'snr': self.parser_args.snr_filter,
             'amplitude_filter': self.parser_args.intensity_filter,
             'min_dist': self.parser_args.min_peak_separation,
-            'fit_baseline': self.parser_args.remove_baseline,
+            'fit_baseline': self.parser_args.fit_baseline,
             'zscore': self.parser_args.zscore_filter,
             'local_filter_size': self.parser_args.filter_width,
             'percentile_filter': self.parser_args.percentile_filter,

--- a/pyquant/worker.py
+++ b/pyquant/worker.py
@@ -102,7 +102,7 @@ class Worker(Process):
             'snr': self.parser_args.snr_filter,
             'amplitude_filter': self.parser_args.intensity_filter,
             'min_dist': self.parser_args.min_peak_separation,
-            'baseline_correction': self.parser_args.remove_baseline,
+            'fit_baseline': self.parser_args.remove_baseline,
             'zscore': self.parser_args.zscore_filter,
             'local_filter_size': self.parser_args.filter_width,
             'percentile_filter': self.parser_args.percentile_filter,


### PR DESCRIPTION
This implements a fourier based baseline subtraction to findAllPeaks prior to peak identification via the `baseline_subtraction` keyword. The raw data is still used to fit the peak against, this only influences what peaks are chosen and subsequent filters (e.g. amplitude_filter is applied on this data instead of data that may have a very bad baseline).

It also deprecates the term `baseline_correction` from findAllPeaks and replaces it with `fit_baseline`, which is more accurate to what is happening.